### PR TITLE
Update the endpoints given the Spinnaker Changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 1. Clone the repo
 2. Run `bundle install` from the project's root
-3. Export an environment variable containing your Spinnaker Endpoint: `export SPINNAKER_ENDPOINT=localhost:9000`
+3. Export an environment variable containing your Spinnaker Endpoint: `export SPINNAKER_ENDPOINT=localhost:8084` (Spinnaker Gate Endpoint)
 4. Leverage the `spincli` command in `spin_cli/bin`
 
 ## Basic Use

--- a/bin/spincli
+++ b/bin/spincli
@@ -6,7 +6,8 @@ require_relative '../lib/commands/pipeline_cmd'
 endpoint = ENV['SPINNAKER_ENDPOINT']
 if endpoint == nil 
   puts 'Please set a SPINNAKER_ENDPOINT environment variable that can be used to hit the RESTful API!'
-  puts 'i.g. localhost:9000 OR spinnaker_endpoint:8080'
+  puts 'This must be the mapped to the gate service!'
+  puts 'i.g. localhost:8084 OR spinnaker_endpoint:8084'
   Process.exit(1)
 end
 

--- a/lib/pipeline/actions.rb
+++ b/lib/pipeline/actions.rb
@@ -12,7 +12,7 @@ module SpinCli
 
     # Creates a pipeline from scratch via a JSON file that meets the Spinnaker JSON Spec.
     def create(json_file)
-      url = "#{@endpoint}/gate/pipelines"
+      url = "#{@endpoint}/pipelines"
       begin
         f = File.read(json_file)
         json_payload = JSON.parse(f)
@@ -28,7 +28,7 @@ module SpinCli
 
     # Deletes a pipeline within Spinnaker for a certain Spinnaker app
     def delete(app, pipeline_name)
-      url = "#{@endpoint}/gate/pipelines/#{app}/#{pipeline_name}"
+      url = "#{@endpoint}/pipelines/#{app}/#{pipeline_name}"
       begin
         RestClient.delete(url)
       rescue => e
@@ -39,7 +39,7 @@ module SpinCli
 
     # Returns a string of all pipeline names and IDs
     def name_ids
-      url = "#{@endpoint}/gate/pipelineConfigs"
+      url = "#{@endpoint}/pipelineConfigs"
       begin
         json_resp = RestClient.get(url, { :accept => :json })
         parse_pipelines_name_id(json_resp)
@@ -51,7 +51,7 @@ module SpinCli
 
     # Returns a pipeline config for a certain Spinnaker app and pipeline
     def get(app, pipeline_name)
-      url = "#{@endpoint}/gate/pipelineConfigs"
+      url = "#{@endpoint}/pipelineConfigs"
       begin
         json_resp = RestClient.get(url, { :accept => :json })
         pipeline_config = parse_pipeline_name(json_resp, app, pipeline_name)
@@ -68,7 +68,7 @@ module SpinCli
       # We need certain data about the pipeline that the user won't have or want
       # to get ahead of their changes.
       pipeline_config = get(app, pipeline_name)
-      url = "#{@endpoint}/gate/pipelines"
+      url = "#{@endpoint}/pipelines"
       begin
         f = File.read(json_file)
         json_payload = JSON.parse(f)


### PR DESCRIPTION
  - 'gate' is no longer included in any of the endpoint calls as we need
  to point at it directly.
  - update the usage and README to reflect this...