### PR TITLE
Add Pipeline interaction functionality.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+Metrics/LineLength:
+  Max: 150
+Metrics/AbcSize:
+  Max: 83
+Metrics/MethodLength:
+  Max: 50
+Metrics/ClassLength:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source "https://rubygems.org"
 
 gem 'cmdparse'
 gem 'rest-client'
+gem 'colorize'
+gem 'hashdiff'

--- a/bin/spincli
+++ b/bin/spincli
@@ -4,7 +4,7 @@ require 'cmdparse'
 require_relative '../lib/commands/pipeline_cmd'
 
 endpoint = ENV['SPINNAKER_ENDPOINT']
-if endpoint == nil 
+if endpoint.nil?
   puts 'Please set a SPINNAKER_ENDPOINT environment variable that can be used to hit the RESTful API!'
   puts 'This must be the mapped to the gate service!'
   puts 'i.g. localhost:8084 OR spinnaker_endpoint:8084'
@@ -13,7 +13,7 @@ end
 
 parser = CmdParse::CommandParser.new(handle_exceptions: :no_help)
 parser.main_options.program_name = 'spincli'
-parser.main_options.version = '0.1.0'
+parser.main_options.version = '1.0.0'
 parser.main_options.banner = 'Interface with the Spinnaker REST API'
 
 parser.add_command(CmdParse::HelpCommand.new, default: true)

--- a/lib/commands/pipeline_cmd.rb
+++ b/lib/commands/pipeline_cmd.rb
@@ -4,83 +4,153 @@ require_relative '../pipeline/actions'
 module SpinCli
   class PipelineCmd < CmdParse::Command
     attr_reader :endpoint
+    attr_reader :global_options_data
     def initialize(endpoint)
       super('pipeline')
       @endpoint = endpoint
+      @options_data = {}
       short_desc('Command for Manipulating pipelines')
-      add_command(PipelineCreateCmd.new(@endpoint))
-      add_command(PipelineDeleteCmd.new(@endpoint))
-      add_command(PipelineUpdateCmd.new(@endpoint))
-      add_command(PipelineReadCmd.new(@endpoint))
-      add_command(PipelineGetNameIdsCmd.new(@endpoint))
+      add_command(PipelineCreateCmd.new(@endpoint, @options_data))
+      add_command(PipelineDeleteCmd.new(@endpoint, @options_data))
+      add_command(PipelineUpdateCmd.new(@endpoint, @options_data))
+      add_command(PipelineReadCmd.new(@endpoint, @options_data))
+      add_command(PipelinePlanCmd.new(@endpoint, @options_data))
+      add_command(PipelineRunCmd.new(@endpoint, @options_data))
+      add_command(PipelineCancelCmd.new(@endpoint, @options_data))
+      add_command(PipelineExecutionsCmd.new(@endpoint, @options_data))
+      add_command(PipelineGetNameIdsCmd.new(@endpoint, @options_data))
+      options.on('-s', '--ssl', 'Enable use of SSL X.509 Client (See README)') { @options_data[:ssl] = true }
     end
   end
 
   class PipelineCreateCmd < CmdParse::Command
-    def initialize(endpoint)
+    def initialize(endpoint, options_data)
       super('create', takes_commands: false)
       @endpoint = endpoint
+      @options_data = options_data
       short_desc('Creates a pipeline from scratch via a JSON file that meets the Spinnaker JSON Spec.')
     end
 
     def execute(pipeline_json_file)
-      puts "Running create pipeline using file: #{pipeline_json_file}" 
-      pipeline_action = SpinCli::PipelineActions.new(@endpoint)
+      puts "Running create pipeline using file: #{pipeline_json_file}"
+      pipeline_action = SpinCli::PipelineActions.new(@endpoint, @options_data)
       pipeline_action.create(pipeline_json_file)
     end
   end
 
   class PipelineGetNameIdsCmd < CmdParse::Command
-    def initialize(endpoint)
+    def initialize(endpoint, options_data)
       super('get-name-ids', takes_commands: false)
       @endpoint = endpoint
+      @options_data = options_data
       short_desc('Obtain all existing pipelines\' names and IDs')
     end
 
     def execute
-      pipeline_action = SpinCli::PipelineActions.new(@endpoint)
+      pipeline_action = SpinCli::PipelineActions.new(@endpoint, @options_data)
       pipeline_action.name_ids
     end
   end
 
   class PipelineReadCmd < CmdParse::Command
-    def initialize(endpoint)
+    def initialize(endpoint, options_data)
       super('get', takes_commands: false)
       @endpoint = endpoint
+      @options_data = options_data
       short_desc('Obtain an existing pipeline\'s config information')
     end
 
     def execute(app, pipeline_name)
-      pipeline_action = SpinCli::PipelineActions.new(@endpoint)
+      pipeline_action = SpinCli::PipelineActions.new(@endpoint, @options_data)
       puts pipeline_action.get(app, pipeline_name).to_json
     end
   end
 
+  class PipelinePlanCmd < CmdParse::Command
+    def initialize(endpoint, options_data)
+      super('plan', takes_commands: false)
+      @endpoint = endpoint
+      @options_data = options_data
+      short_desc('See desired pipelines changes before updating')
+    end
+
+    def execute(app, pipeline_name, updated_pipeline_file)
+      pipeline_action = SpinCli::PipelineActions.new(@endpoint, @options_data)
+      pipeline_action.plan(app, pipeline_name, updated_pipeline_file)
+    end
+  end
+
   class PipelineDeleteCmd < CmdParse::Command
-    def initialize(endpoint)
+    def initialize(endpoint, options_data)
       super('delete', takes_commands: false)
       @endpoint = endpoint
+      @options_data = options_data
       short_desc('Delete an existing pipeline')
     end
 
     def execute(app, pipeline_name)
       puts "Running delete pipeline for spinnaker app: #{app} and pipeline: #{pipeline_name}"
-      pipeline_action = SpinCli::PipelineActions.new(@endpoint)
+      pipeline_action = SpinCli::PipelineActions.new(@endpoint, @options_data)
       pipeline_action.delete(app, pipeline_name)
     end
   end
 
   class PipelineUpdateCmd < CmdParse::Command
-    def initialize(endpoint)
+    def initialize(endpoint, options_data)
       super('update', takes_commands: false)
       @endpoint = endpoint
+      @options_data = options_data
       short_desc('Update an existing pipeline')
     end
 
-    def execute(pipeline_json_file, app, pipeline_name)
-      puts "Running update pipeline using file: #{pipeline_json_file}" 
-      pipeline_action = SpinCli::PipelineActions.new(@endpoint)
-      pipeline_action.update(pipeline_json_file, app, pipeline_name)
+    def execute(app, pipeline_name, pipeline_json_file)
+      puts "Running update pipeline using file: #{pipeline_json_file}"
+      pipeline_action = SpinCli::PipelineActions.new(@endpoint, @options_data)
+      pipeline_action.update(app, pipeline_name, pipeline_json_file)
+    end
+  end
+
+  class PipelineRunCmd < CmdParse::Command
+    def initialize(endpoint, options_data)
+      super('run', takes_commands: false)
+      @endpoint = endpoint
+      @options_data = options_data
+      short_desc('Run a pipeline (timeout threshold default: 1800 seconds)')
+    end
+
+    def execute(app, pipeline_name, timeout_threshold = 1800)
+      puts "Running pipeline: #{pipeline_name}"
+      pipeline_action = SpinCli::PipelineActions.new(@endpoint, @options_data)
+      pipeline_action.run(app, pipeline_name, timeout_threshold)
+    end
+  end
+
+  class PipelineCancelCmd < CmdParse::Command
+    def initialize(endpoint, options_data)
+      super('cancel', takes_commands: false)
+      @endpoint = endpoint
+      @options_data = options_data
+      short_desc('Cancel a pipeline execution')
+    end
+
+    def execute(pipeline_execution_id)
+      puts "Canceling pipeline execution id: #{pipeline_execution_id}"
+      pipeline_action = SpinCli::PipelineActions.new(@endpoint, @options_data)
+      pipeline_action.cancel(pipeline_execution_id)
+    end
+  end
+
+  class PipelineExecutionsCmd < CmdParse::Command
+    def initialize(endpoint, options_data)
+      super('executions', takes_commands: false)
+      @endpoint = endpoint
+      @options_data = options_data
+      short_desc('Lists running/not started pipeline executions')
+    end
+
+    def execute(app, pipeline_name)
+      pipeline_action = SpinCli::PipelineActions.new(@endpoint, @options_data)
+      pipeline_action.executions(app, pipeline_name)
     end
   end
 end

--- a/lib/pipeline/actions.rb
+++ b/lib/pipeline/actions.rb
@@ -1,112 +1,175 @@
-require 'rest-client'
+require_relative '../utils/pipeline_compare'
+require_relative '../utils/http'
 require 'json'
+require 'colorize'
+require 'uri'
 
 module SpinCli
   class PipelineActions
+    attr_reader :http
 
-    attr_reader :endpoint
-
-    def initialize(endpoint)
-      @endpoint  = endpoint
+    def initialize(endpoint, options_data)
+      @endpoint = endpoint
+      @options_data = options_data
+      @http = SpinCli::Utils::Http.new(@endpoint, @options_data)
     end
 
     # Creates a pipeline from scratch via a JSON file that meets the Spinnaker JSON Spec.
     def create(json_file)
-      url = "#{@endpoint}/pipelines"
-      begin
-        f = File.read(json_file)
-        json_payload = JSON.parse(f)
-        RestClient.post(url,
-                        json_payload.to_json,
-                        { :content_type => :json, :accept => :json }
-                       )
-      rescue => e
-        puts "Error creating pipeline: #{e}"
-        Process.exit(1)
-      end
+      pipeline_json = File.read(json_file)
+      @http.pipelines.post pipeline_json
+    rescue StandardError => e
+      puts "Error creating pipeline: #{e}"
+      Process.exit(1)
     end
 
     # Deletes a pipeline within Spinnaker for a certain Spinnaker app
     def delete(app, pipeline_name)
-      url = "#{@endpoint}/pipelines/#{app}/#{pipeline_name}"
-      begin
-        RestClient.delete(url)
-      rescue => e
-        puts "Error deleting pipeline: #{e}"
-        Process.exit(1)
-      end
+      @http.pipelines[URI.escape("#{app}/#{pipeline_name}")].delete
+    rescue StandardError => e
+      puts "Error deleting pipeline: #{e}"
+      Process.exit(1)
     end
 
     # Returns a string of all pipeline names and IDs
     def name_ids
-      url = "#{@endpoint}/pipelineConfigs"
-      begin
-        json_resp = RestClient.get(url, { :accept => :json })
-        parse_pipelines_name_id(json_resp)
-      rescue => e
-        puts "Error getting all pipeline names and IDs from Spinnaker: #{e}"
-        Process.exit(1)
-      end
+      parse_pipelines_name_id(@http.pipelineConfigs.get)
+    rescue StandardError => e
+      puts "Error getting all pipeline names and IDs from Spinnaker: #{e}"
+      Process.exit(1)
     end
 
     # Returns a pipeline config for a certain Spinnaker app and pipeline
     def get(app, pipeline_name)
-      url = "#{@endpoint}/pipelineConfigs"
-      begin
-        json_resp = RestClient.get(url, { :accept => :json })
-        pipeline_config = parse_pipeline_name(json_resp, app, pipeline_name)
-        return pipeline_config
-      rescue => e
-        puts "Error reading pipelines configs from Spinnaker: #{e}"
-        Process.exit(1)
-      end
+      parse_pipeline_name(@http.pipelineConfigs.get,
+                          app,
+                          pipeline_name)
+    rescue StandardError => e
+      puts "Error reading pipelines configs from Spinnaker: #{e}"
+      Process.exit(1)
     end
 
-    # This needs to read the pipeline config in order to get the 
+    # Retrieve current state Pipeline and perform a comparision with
+    # desired changes. Then try to create it (separate from the existing
+    # pipeline).
+    def plan(app, pipeline_name, updated_pipeline)
+      # diff existing_pipeline_json to updated_pipeline_json
+      updated_pipeline_hash = JSON.parse(File.read(updated_pipeline))
+      updated_pipeline_hash['name'] = pipeline_name
+      SpinCli::Utils::Pipeline.compare(get(app, pipeline_name), updated_pipeline_hash)
+
+      # Try to create the pipeline and then remove it
+      # Create it under a different name
+      rng = Random.new(Time.now.to_i)
+      random_pipeline_number = rng.rand(1000)
+      updated_pipeline_hash['name'] = "#{pipeline_name}-#{random_pipeline_number}"
+
+      @http.pipelines.post updated_pipeline_hash.to_json
+      puts "Successfully validated pipeline changes for: #{pipeline_name}".colorize(:green)
+      puts "\nTo Update - Run: #{$PROGRAM_NAME} pipeline update #{app} #{pipeline_name} " \
+           "#{updated_pipeline}".colorize(:green)
+
+      # Cleanup validated pipeline
+      delete(app, "#{pipeline_name}-#{random_pipeline_number}")
+    rescue StandardError => e
+      puts "Error performing a plan on #{pipeline_name}: #{e}"
+    end
+
+    # This needs to read the pipeline config in order to get the
     # id, ts, and name associated with it in order to update the correct pipeline.
-    def update(json_file, app, pipeline_name)
+    def update(app, pipeline_name, json_file)
       # We need certain data about the pipeline that the user won't have or want
       # to get ahead of their changes.
       pipeline_config = get(app, pipeline_name)
-      url = "#{@endpoint}/pipelines"
       begin
         f = File.read(json_file)
-        json_payload = JSON.parse(f)
-        json_payload['id'] = pipeline_config['id']
-        json_payload['application'] = pipeline_config['application']
-        json_payload['name'] = pipeline_config['name']
-        json_payload['updateTs'] = pipeline_config['updateTs']
-        RestClient.post(url,
-                        json_payload.to_json,
-                        { :content_type => :json, :accept => :json }
-                       )
-      rescue => e
+        updated_pipeline_cfg = JSON.parse(f)
+        updated_pipeline_cfg['id'] = pipeline_config['id']
+        updated_pipeline_cfg['application'] = pipeline_config['application']
+        updated_pipeline_cfg['name'] = pipeline_config['name']
+        updated_pipeline_cfg['updateTs'] = pipeline_config['updateTs']
+        @http.pipelines.post updated_pipeline_cfg.to_json
+      rescue StandardError => e
         puts "Error updating pipeline: #{e}"
         Process.exit(1)
       end
     end
 
-    private 
+    def run(app, pipeline_name, timeout_threshold_seconds)
+      payload = { type: 'manual', dryRun: false }
+      @http.pipelines[URI.escape("#{app}/#{pipeline_name}")].post payload.to_json
+      pipeline_config_id = get(app, pipeline_name)['id']
+
+      status = check_pipeline_status(pipeline_config_id)
+      timeout = 0
+
+      while (status == 'RUNNING' || status == 'NOT_STARTED') && \
+            timeout < timeout_threshold_seconds.to_i
+
+        puts "Pipeline Status: #{status}"
+        sleep 5
+        status = check_pipeline_status(pipeline_config_id)
+        timeout += 5
+      end
+
+      if timeout >= timeout_threshold_seconds.to_i
+        puts "Timeout threshold of #{timeout_threshold_seconds} seconds reached!"
+        puts "Please investigate pipeline: #{pipeline_name}."
+        Process.exit(1)
+      end
+
+      puts "Pipeline Completed Status: #{check_pipeline_status(pipeline_config_id)}"
+    rescue StandardError => e
+      puts "Unable to run pipeline #{pipeline_name}: #{e}"
+      Process.exit(1)
+    end
+
+    def cancel(execution_id)
+      reason = { reason: 'spincli cancel' }
+      @http.pipelines["#{execution_id}/cancel"].put reason.to_json
+    rescue StandardError => e
+      puts "Unable to cancel pipeline #{pipeline_name}: #{e}"
+      Process.exit(1)
+    end
+
+    def executions(app, pipeline_name)
+      executions = JSON.parse(@http.execution_status(get(app, pipeline_name)['id'], 30).get)
+      executions.each do |execution|
+        next unless execution['status'] == 'RUNNING' || execution['status'] == 'NOT_STARTED'
+        puts "id:#{execution['id']} user:#{execution['authentication']['user']} status: #{execution['status']}"
+      end
+    end
+
+    private
+
     # Return a singleton pipeline's JSON config
     def parse_pipeline_name(json_resp, app, pipeline_name)
       # We get an array of configs back from the API in JSON form - parse them.
-      json_configs = JSON.parse(json_resp)
+      configs = JSON.parse(json_resp)
       count = 0
-      json_configs.each do |config|
-        break if config['name'] == pipeline_name
+      configs.each do |config|
+        break if config['name'] == pipeline_name && config['application'] == app
         count += 1
       end
 
-      return json_configs[count]
+      configs[count]
     end
 
     # Return the name and IDs of all the pipelines we have
     def parse_pipelines_name_id(json_resp)
-      json_configs = JSON.parse(json_resp)
-      json_configs.each do |config|
+      configs = JSON.parse(json_resp)
+      configs.each do |config|
         puts "#{config['name']}:#{config['id']}"
       end
     end
 
+    def check_pipeline_status(pipeline_config_id)
+      parsed_results = JSON.parse(@http.execution_status(pipeline_config_id).get)
+      parsed_results.each do |result|
+        return result['status']
+      end
+    rescue StandardError => e
+      puts "Unable to retrieve pipeline status: #{e}"
+    end
   end
 end

--- a/lib/utils/http.rb
+++ b/lib/utils/http.rb
@@ -1,0 +1,70 @@
+require 'rest-client'
+
+module SpinCli
+  module Utils
+    class Http
+      SAML_SESSION_COOKIE_ID = ENV['SAML_SESSION_COOKIE_ID'] || ''
+      CLIENT_CERT = ENV['CLIENT_CERT'] || ''
+      CLIENT_KEY = ENV['CLIENT_KEY'] || ''
+      CLIENT_KEY_PASSPHRASE = ENV['CLIENT_KEY_PASSPHRASE'] || ''
+      # CA_CERTIFICATE = ENV['CA_CERTIFICATE'] || ''
+
+      def initialize(endpoint, options_data)
+        @endpoint = endpoint
+        @options_data = options_data
+      end
+
+      def pipelines
+        if @options_data[:ssl]
+          rest_client_resource_ssl("#{@endpoint}/pipelines")
+        else
+          rest_client_resource("#{@endpoint}/pipelines")
+        end
+      end
+
+      def pipelineConfigs
+        if @options_data[:ssl]
+          rest_client_resource_ssl("#{@endpoint}/pipelineConfigs")
+        else
+          rest_client_resource("#{@endpoint}/pipelineConfigs")
+        end
+      end
+
+      def execution_status(pipeline_config_id, limit = 1)
+        if @options_data[:ssl]
+          rest_client_resource_ssl("#{@endpoint}/executions?pipelineConfigIds=#{pipeline_config_id}&limit=#{limit}")
+        else
+          rest_client_resource("#{@endpoint}/executions?pipelineConfigIds=#{pipeline_config_id}&limit=#{limit}")
+        end
+      end
+
+      private
+
+      def rest_client_resource(url)
+        RestClient::Resource.new(url,
+                                 headers: {
+                                   content_type: 'application/json',
+                                   accept: 'application/json',
+                                   cookies: {
+                                     'SESSION' => SAML_SESSION_COOKIE_ID.to_s
+                                   }
+                                 })
+      end
+
+      def rest_client_resource_ssl(url)
+        RestClient::Resource.new(url,
+                                 headers: {
+                                   content_type: 'application/json',
+                                   accept: 'application/json',
+                                   cookies: {
+                                     'SESSION' => SAML_SESSION_COOKIE_ID.to_s
+                                   }
+                                 },
+                                 ssl_client_cert: OpenSSL::X509::Certificate.new(File.read(CLIENT_CERT.to_s)),
+                                 ssl_client_key: OpenSSL::PKey::RSA.new(File.read(CLIENT_KEY.to_s),
+                                                                        CLIENT_KEY_PASSPHRASE.to_s),
+                                 verify_ssl: OpenSSL::SSL::VERIFY_NONE)
+      end
+    end
+  end
+end

--- a/lib/utils/pipeline_compare.rb
+++ b/lib/utils/pipeline_compare.rb
@@ -1,0 +1,35 @@
+require 'colorize'
+require 'hashdiff'
+
+module SpinCli
+  module Utils
+    class Pipeline
+      def self.compare(existing_pipeline_json, updated_pipeline_json)
+        puts "The following changes will take place:\n\n"
+        diff = HashDiff.diff(existing_pipeline_json, updated_pipeline_json)
+
+        diff.each do |change|
+          next if change.include?('id') || change.include?('lastModifiedBy') || \
+                  change.include?('index') || change.include?('updateTs')
+          if change[0] == '+'
+            convert_diff(change, :yellow)
+          elsif change[0] == '-'
+            convert_diff(change, :red)
+          elsif change[0] == '~'
+            convert_diff(change, :cyan)
+          else
+            puts "Unable to detect type of change: #{change}"
+          end
+        end
+      end
+
+      def self.convert_diff(changes, color)
+        change_type = changes.shift
+        change_hash = {}
+        change_hash[changes.shift] = changes
+
+        puts "#{change_type} #{JSON.pretty_generate(change_hash)}".colorize(color)
+      end
+    end
+  end
+end


### PR DESCRIPTION
  - Support setting a session cookie for SAML
  - Add Pipeline Plan command:
    - Takes desired pipeline JSON, compares/diffs what's currently live,
    outputs diff for view, and then creates a separate test pipeline to
    validate pipeline JSON
  - Add Pipeline Run command:
    - Supports running a pipeline "manually"
    - Accepts a timeout for pipeline run
  - Add rubocop and lint everything.
  - Consolidate http client logic.
  - Add SSL support
  - Add Pipeline Executions command:
    - Lists all Running/Not Started pipeline exections
  - Add Pipeline Cancel command
    - Cancel a pipeline execution ID.